### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-audiodecoder-upse
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev,
-               libkodiplatform-dev (>= 17.1.0), zlib1g-dev
+               zlib1g-dev
 Standards-Version: 3.9.6
 Section: libs
 


### PR DESCRIPTION
The audiodecoder.upse binary addon does not use kodi-platform.
Remove existing references from debian/control.