### PR TITLE
Change to use for Kodi Matrix and version increase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# build artifacts
+build/
+audiodecoder.*/addon.xml
+
+# Debian build files
+debian/changelog
+debian/files
+debian/*.log
+debian/*.substvars
+debian/.debhelper/
+debian/tmp/
+debian/kodi-audiodecoder-*/
+obj-x86_64-linux-gnu/
+
+# commonly used editors
+# vim
+*.swp
+
+# Eclipse
+*.project
+*.cproject
+.classpath
+*.sublime-*
+.settings/
+
+# KDevelop 4
+*.kdev4
+
+# gedit
+*~
+
+# CLion
+/.idea
+
+# clion
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,7 @@ matrix:
       sudo: required
       compiler: clang
     - os: osx
-      osx_image: xcode9
-
-#
-# Some of the OS X images don't have cmake, contrary to what people
-# on the Internet say
-#
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
+      osx_image: xcode10.2
 
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
@@ -39,7 +30,7 @@ before_install:
 #
 before_script:
   - cd $TRAVIS_BUILD_DIR/..
-  - git clone --branch Leia --depth=1 https://github.com/xbmc/xbmc.git
+  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
   - cd ${app_id} && mkdir build && cd build
   - mkdir -p definition/${app_id}
   - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Leia")
+buildPlugin(version: "Matrix")

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also make sure you follow this README from the branch in question.
 The following instructions assume you will have built Kodi already in the `kodi-build` directory 
 suggested by the README.
 
-1. `git clone --branch Leia https://github.com/xbmc/xbmc.git`
+1. `git clone --branch master https://github.com/xbmc/xbmc.git`
 2. `git clone https://github.com/xbmc/audiodecoder.upse.git`
 3. `cd audiodecoder.upse && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=audiodecoder.upse -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # audiodecoder.upse addon for Kodi
 
-This is a [Kodi](http://kodi.tv) audio decoder addon for PSF files.
+This is a [Kodi](https://kodi.tv) audio decoder addon for PSF files.
 
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.upse.svg?branch=master)](https://travis-ci.org/xbmc/audiodecoder.upse)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.upse?svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-upse)
+[![Build Status](https://travis-ci.org/xbmc/audiodecoder.upse.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.upse/branches)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.upse?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-upse?branch=Matrix)
 
 ## Build instructions
 
 When building the addon you have to use the correct branch depending on which version of Kodi you're building against. 
-For example, if you're building the `master` branch of Kodi you should checkout the `master` branch of this repository. 
+If you want to build the addon to be compatible with the latest kodi `master` commit, you need to checkout the branch with the current kodi codename.
 Also make sure you follow this README from the branch in question.
 
 ### Linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: BuildNr.{build}
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 shallow_clone: true
 
@@ -10,20 +10,20 @@ environment:
   app_id: audiodecoder.upse
 
   matrix:
-    - GENERATOR: "Visual Studio 14"
+    - GENERATOR: "Visual Studio 15"
       CONFIG: Release
-    - GENERATOR: "Visual Studio 14 Win64"
+    - GENERATOR: "Visual Studio 15 Win64"
       CONFIG: Release
-    - GENERATOR: "Visual Studio 14 Win64"
+    - GENERATOR: "Visual Studio 15 Win64"
       CONFIG: Release
-      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
-    - GENERATOR: "Visual Studio 14 ARM"
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+    - GENERATOR: "Visual Studio 15 ARM"
       CONFIG: Release
-      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
 
 build_script:
   - cd ..
-  - git clone --branch Leia --depth=1 https://github.com/xbmc/xbmc.git
+  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
   - cd %app_id%
   - mkdir build
   - cd build

--- a/audiodecoder.upse/addon.xml.in
+++ b/audiodecoder.upse/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.upse"
-  version="2.0.0"
+  version="2.1.0"
   name="PSF Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/UPSECodec.cpp
+++ b/src/UPSECodec.cpp
@@ -83,8 +83,7 @@ struct UPSEContext
 
 }
 
-class CUPSECodec : public kodi::addon::CInstanceAudioDecoder,
-                   public kodi::addon::CAddonBase
+class ATTRIBUTE_HIDDEN CUPSECodec : public kodi::addon::CInstanceAudioDecoder
 {
 public:
   CUPSECodec(KODI_HANDLE instance) :


### PR DESCRIPTION
Related to xbmc/xbmc#16431 and xbmc/xbmc#16452

> note: Leia is still default branch

**WARNING:** There on test comes a Kodi crash on end of file!

@notspiff Do you know something about the crash?

Here the bt:
```
#0  0x00007fff82fd380f in upse_ps1_spu_render () at /home/alwin/.kodi/addons/audiodecoder.upse/audiodecoder.upse.so.2.2.0
#1  0x00007fff82fd1aab in upse_ps1_counter_run () at /home/alwin/.kodi/addons/audiodecoder.upse/audiodecoder.upse.so.2.2.0
#2  0x00007fff82fd686d in upse_r3000_cpu_execute_render () at /home/alwin/.kodi/addons/audiodecoder.upse/audiodecoder.upse.so.2.2.0
#3  0x00007fff82fcaf6d in kodi::addon::CInstanceAudioDecoder::ADDON_ReadPCM(AddonInstance_AudioDecoder const*, unsigned char*, int, int*) ()
    at /home/alwin/.kodi/addons/audiodecoder.upse/audiodecoder.upse.so.2.2.0
#4  0x0000555556a0815f in CAudioDecoder::ReadSamples(int) ()
#5  0x0000555556a0f319 in PAPlayer::ProcessStreams(double&) ()
#6  0x0000555556a0d8c4 in PAPlayer::Process() ()
#7  0x000055555617e2d5 in CThread::Action() ()
#8  0x000055555617fc6d in  ()
#9  0x00005555561800b2 in  ()
#10 0x00007ffff3b24630 in  () at /lib/x86_64-linux-gnu/libstdc++.so.6
#11 0x00007ffff7f86182 in start_thread (arg=<optimized out>) at pthread_create.c:486
#12 0x00007ffff3d55b1f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```